### PR TITLE
Added workaround for issue #1

### DIFF
--- a/mqlight-transport.js
+++ b/mqlight-transport.js
@@ -101,6 +101,16 @@ module.exports = function(options) {
 	}
 
 	function hook_client_mqlight(args, clientdone) {
+
+        /* 
+         * Issue in upstream attaching 'ID' in args that is not compatable with
+         * mqlight requirements. If the pattern matches, delete the id. This
+         * will cause mqlight to generate a ID automaticly. 
+         */
+
+        if(args.id.indexOf('type:mqlight') >= 0)
+            delete args.id;
+
 		var seneca = this
 		var type = args.type
 		var client_options = seneca.util.clean(_.extend({}, options[type], args))


### PR DESCRIPTION
Added workaround for issue #1 to the function: hook_client_mqlight.  The upstream seneca.add method is returning a field _id_ in the _args_ handed to hook_client_mqlight. This ID contains invalid characters that causes a failure to connect to mqlight.  This workaround checks for 'type:mqlight' which is always present in the above case.  It is not an ideal solution because the calling code might include this string as a intentional value. However, the **:** is invalid for a mqlight ID and would cause a failure.  In effect, this workaround will solve issue #1.  The better solution would be to move the mqlight id to a different field, or fix in upstream seneca code.
